### PR TITLE
Added simple multi-checkbox filtering

### DIFF
--- a/app/views/crud_toolbox/_list_view.html.haml
+++ b/app/views/crud_toolbox/_list_view.html.haml
@@ -21,10 +21,18 @@
                   %span.order= fa_icon 'sort'
             - if col.order.present? && !list_view.locals[:no_filter]
               - if col.values.present?
-                %select.form-control.no-select2.filter
-                  %option(value="")
-                  - col.values.each do |v|
-                    %option{value: v, selected: v == list_view.filter[col.order.to_s]}= v
+                - if col.multi?
+                  .filter-multi
+                    - col.values.each do |v|
+                      .checkbox
+                        %label
+                          %input{ name: col.order, type: :checkbox, value: v}
+                          = v
+                - else
+                  %select.form-control.no-select2.filter
+                    %option{ value: '' }
+                    - col.values.each do |v|
+                      %option{value: v, selected: v == list_view.filter[col.order.to_s]}= v
               - else
                 %input.form-control.filter(type="search" placeholder="Filter" value="#{list_view.filter[col.order.to_s]}")
 

--- a/crud_toolbox.gemspec
+++ b/crud_toolbox.gemspec
@@ -2,7 +2,7 @@ $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name = 'crud_toolbox'
-  s.version = '0.1'
+  s.version = '0.2'
   s.authors = ['Martin Tournoij']
   s.email = ['martin@lico.nl']
   s.homepage = 'https://github.com/bluerail/'

--- a/lib/crud_toolbox/column.rb
+++ b/lib/crud_toolbox/column.rb
@@ -2,13 +2,18 @@ module CrudToolbox
   class Column
     attr_reader :header, :order, :where, :class, :sort_as, :values
 
-    def initialize(header, order: nil, where: nil, klass: nil, sort_as: nil, values: nil)
+    def initialize(header, order: nil, where: nil, klass: nil, sort_as: nil, values: nil, multi: nil)
       @header = header
       @order = order
       @where = where
       @class = klass
       @sort_as = sort_as
       @values = values
+      @multi = multi
+    end
+
+    def multi?
+      !!@multi
     end
   end
 end

--- a/lib/crud_toolbox/list_view/base.rb
+++ b/lib/crud_toolbox/list_view/base.rb
@@ -38,7 +38,7 @@ module CrudToolbox
           # error out on unknown columns (feature!)
           c = get_col k
 
-          # Column doesn't exis so move on to the next one
+          # Column doesn't exist so move on to the next one
           next if c.nil?
 
           if k.in? record_class.columns.map(&:name)
@@ -133,13 +133,13 @@ module CrudToolbox
       end
 
       # Create column
-      def col(header, order = false, where: nil, sort_as: nil, values: nil)
+      def col(header, order = false, where: nil, sort_as: nil, values: nil, multi: nil)
         if header.is_a? Symbol
           order = header if order == false
           header = col_title header
         end
 
-        Column.new header, order: order, where: where, sort_as: sort_as, values: values
+        Column.new header, order: order, where: where, sort_as: sort_as, values: values, multi: multi
       end
 
       # Create a "empty" column without header; useful for buttons and the like
@@ -180,7 +180,7 @@ module CrudToolbox
         }
       end
 
-      def enum_col(model, column, translate_value = true)
+      def enum_col(model, column, translate_value = true, multi: false, sort_as: nil)
         column_p = column.to_s.pluralize
         values = model.send column_p
 
@@ -192,7 +192,7 @@ module CrudToolbox
           tr_values = values
         end
 
-        col(column, column, values: tr_values.keys, where: lambda do |arel, value|
+        col(column, column, values: tr_values.keys, multi: multi, sort_as: sort_as, where: lambda do |arel, value|
           sql = []
           tr_values.each { |k, v| sql << v if k.match(/#{value}/i) }
 


### PR DESCRIPTION
This was primarily added and tested with `enum_col`.

Passing `multi: true` to `enum_col` will allow for filtering over multiple values. To do this, it presents a collection of checkboxes. Selecting none of the columns assumes that no filtering should be done, and is equivalent to selecting all of them.

Currently the display of this won't easily fit in with the rest of the columns, so I plan to fix that with a future commit.

Also added `sort_as` for `enum_col`, as I was experiencing issues with ambiguity.
